### PR TITLE
Migrate to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rsget"
 version = "0.1.0"
 authors = ["Otavio Salvador <otavio@ossystems.com.br>"]
 license = "Apache-2.0"
+edition = "2018"
 readme = "README.md"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ fn main() -> Result<(), ExitFailure> {
                 "Couldn't download URL: {}. Error: {:?}",
                 cmdline.url,
                 resp.status(),
-            )).into());
+            ))
+            .into());
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate exitfailure;
-extern crate failure;
-extern crate indicatif;
-extern crate reqwest;
-extern crate structopt;
-
 use std::{
     fs,
     io::{self, copy, Read},
@@ -15,6 +9,7 @@ use std::{
 };
 
 use exitfailure::ExitFailure;
+use failure;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::{header, Client};
 use structopt::StructOpt;


### PR DESCRIPTION
This applies the changes which are need to adapt the code to the Rust
2018 edition.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>